### PR TITLE
Replaced legacy \bf with modern \textbf

### DIFF
--- a/resume.cls
+++ b/resume.cls
@@ -95,7 +95,7 @@
 % Defines the rSection environment for the large sections within the CV
 \newenvironment{rSection}[1]{ % 1 input argument - section name
   \sectionskip
-  \MakeUppercase{\textbf #1} % Section title
+  \MakeUppercase{\textbf {#1}} % Section title
   \sectionlineskip
   \hrule % Horizontal line
   \begin{list}{}{ % List for each individual item in the section

--- a/resume.cls
+++ b/resume.cls
@@ -95,7 +95,7 @@
 % Defines the rSection environment for the large sections within the CV
 \newenvironment{rSection}[1]{ % 1 input argument - section name
   \sectionskip
-  \MakeUppercase{\bf #1} % Section title
+  \MakeUppercase{\textbf #1} % Section title
   \sectionlineskip
   \hrule % Horizontal line
   \begin{list}{}{ % List for each individual item in the section


### PR DESCRIPTION
The \bf command inside the \MakeUppercase command will just swich bold on for the remainer of the document, and isn't limited to the \MakeUppercase command. This changed around 2022, and this repo was originally for a 2019 article.

Changing \bf to \textbf fixes this.